### PR TITLE
doc: add appimageTools

### DIFF
--- a/pasta/src/eval.nix
+++ b/pasta/src/eval.nix
@@ -26,6 +26,7 @@ let
     rustTools = collectFns pkgs.rustPackages {
       initialPath = [ "pkgs" "rustPackages" ];
     };
+    appimageTools = collectFns pkgs.appimageTools { initialPath = [ "pkgs" "appimageTools" ]; };
 
     ############# Non-recursive analysis sets (pkgs.<nested>)
     # pkgs cannot be analysed recursively


### PR DESCRIPTION
@DanielSidhion. I just found your issue (https://github.com/NixOS/nixpkgs/issues/276033) 

- Added all functions of appimageTools. (collectFns is a recursive analysis)

https://github.com/hsjobeki/nixpkgs/blob/migrate-doc-comments/pkgs/build-support/appimage/default.nix#L41:C18
Is where the documentation (doc-comment) should be placed. If anyone decides to write automatically discovered reference documentation.

- [x] `nix build .#ui`