### PR TITLE
Fix: pkgs.* content of extensible functions not properly propagated

### DIFF
--- a/pesto/src/alias.rs
+++ b/pesto/src/alias.rs
@@ -86,6 +86,7 @@ pub fn find_aliases(item: &Docs, list: &Vec<&Docs>) -> AliasList {
     res
 }
 
+#[derive(Debug)]
 pub struct FnCategories<'a> {
     pub primop: Vec<&'a Docs>,
     pub casual: Vec<&'a Docs>,
@@ -120,6 +121,22 @@ pub fn categorize(data: &Vec<Docs>) -> FnCategories {
     for item in data.iter() {
         if let Some(lambda) = &item.docs.lambda {
             if lambda.isFunctor == Some(true) {
+                // A functor takes self as first argument
+                // Subtract the first argument from the count of applied arguments.
+                match lambda.countApplied.map(|s|s-1) {
+                    // Some(0) | None => {
+                    Some(0) => {
+                        if lambda.isPrimop {
+                            primop_lambdas.push(&item);
+                        }
+                        if !lambda.isPrimop {
+                            non_primop_lambdas.push(&item);
+                        }
+                    }
+                    _ => {
+                        partially_applieds.push(&item);
+                    }
+                }
                 continue;
             }
             match lambda.countApplied {

--- a/pesto/src/main.rs
+++ b/pesto/src/main.rs
@@ -147,7 +147,6 @@ fn find_document_content<'a>(
                 pos_type: Some(PositionType::Attribute),
             }),
         }),
-        // _ if item. item.lambda_content().is_some() => item.lambda_content(),
         _ => match item.fst_alias_content(&all) {
             Some(d) => Some(d),
             None => item.lambda_content(),

--- a/pesto/src/pasta.rs
+++ b/pesto/src/pasta.rs
@@ -97,7 +97,7 @@ impl<'a> Lookups<'a> for Docs {
             .lambda
             .as_ref()
             .map(|i| {
-                if i.countApplied == Some(0) || (i.countApplied == None && i.isPrimop) {
+                if i.countApplied == Some(0) || (i.countApplied == None && i.isPrimop) || (i.countApplied == Some(1) && i.isFunctor == Some(true)) {
                     Some(ContentSource {
                         content: i.content.as_ref().map(|inner| dedent(inner)),
                         source: Some(SourceOrigin {
@@ -146,7 +146,7 @@ impl<'a> Lookups<'a> for Docs {
                 });
                 x
             }
-            _ => None,
+            None => None,
         }
     }
 }

--- a/pesto/src/position.rs
+++ b/pesto/src/position.rs
@@ -148,9 +148,9 @@ impl<'a> DocComment<'a> for DocIndex<'a> {
             if let Some(Some(expr)) = expr {
                 let doc = match expr.kind() {
                     rnix::SyntaxKind::NODE_LAMBDA => {
-                        let (outer_lambda, count_applied) = get_parent_lambda(&expr);
+                        let (_outer_lambda, count_applied) = get_parent_lambda(&expr);
                         NixDocComment {
-                            content: get_expr_docs(&outer_lambda),
+                            content: get_expr_docs(&expr),
                             count_applied: Some(count_applied),
                         }
                     }


### PR DESCRIPTION
Fixes: Some functions i.e. pkgs.* are wrapped with makeExtensible, this creates a functor around the original function.
The functor is unwrapped already, but the underlying docs where not displayed properly.