### PR TITLE
builtins.types: fix type for `builtins.tail`

### DIFF
--- a/salt/src/builtins.types.json
+++ b/salt/src/builtins.types.json
@@ -95,7 +95,7 @@
   "stringLength": { "fn_type": "stringLength :: String -> Int" },
   "sub": { "fn_type": "sub :: Number -> Number -> Number" },
   "substring": { "fn_type": "substring :: Int -> Int -> String -> String" },
-  "tail": { "fn_type": "tail :: [a] -> a" },
+  "tail": { "fn_type": "tail :: [a] -> [a]" },
   "throw": { "fn_type": "throw :: String" },
   "toFile": { "fn_type": "toFile :: Path -> String -> StorePath " },
   "toJSON": { "fn_type": "toJSON :: a -> String" },


### PR DESCRIPTION
I think this type has an error

```
nix-repl> builtins.tail ["a" "b"]
[ "b" ]

nix-repl> builtins.tail [1]
[ ]
```