### PR TITLE
Make computed data available via a JSON API endpoint

### DIFF
--- a/website/src/app/api/v1/data/route.ts
+++ b/website/src/app/api/v1/data/route.ts
@@ -1,0 +1,5 @@
+import { data, builtinTypes, upstreamInfo } from "@/models/data";
+
+export async function GET(request: Request) {
+    return Response.json({ data, builtinTypes, upstreamInfo });
+}

--- a/website/src/app/f/[...path]/page.tsx
+++ b/website/src/app/f/[...path]/page.tsx
@@ -1,7 +1,7 @@
 import { HighlightBaseline } from "@/components/HighlightBaseline";
 import { ShareButton } from "@/components/ShareButton";
 import { BackButton } from "@/components/BackButton";
-import { Doc, data, manualLinks } from "@/models/data";
+import { Doc, data, manualLinks, upstreamInfo } from "@/models/data";
 import { getPrimopDescription } from "@/models/primop";
 import { extractExcerpt, extractHeadings, parseMd } from "@/utils";
 import { Box, Divider, Typography, Link, Chip } from "@mui/material";
@@ -11,7 +11,6 @@ import React, { Suspense } from "react";
 import { PositionLink } from "@/components/PositionLink";
 import { SearchNav } from "@/components/SearchNav";
 
-import upstreamInfo from "@/models/data/meta.json" assert { type: "json" };
 import fs from "fs";
 import path from "path";
 import { Metadata, ResolvingMetadata } from "next";

--- a/website/src/models/data/index.ts
+++ b/website/src/models/data/index.ts
@@ -1,6 +1,7 @@
 import all from "./data.json" assert { type: "json" };
 import types from "./builtins.types.json" assert { type: "json" };
 import links from "./manual-link.map.json" assert { type: "json" };
+import meta from "./meta.json" assert { type: "json" };
 
 export type ManualLink = {
   id: string;
@@ -63,3 +64,10 @@ export type BuiltinTypes = {
 };
 
 export const builtinTypes = types as BuiltinTypes;
+
+export type UpstreamInfo = {
+  rev: string;
+  lastModified: number;
+}
+
+export const upstreamInfo = meta as UpstreamInfo;


### PR DESCRIPTION
Render a static JSON response at /api/v1/data that returns the exports of @/models/data, namely,
```
{
    "data": contents of data.json,
    "builtinTypes": contents of builtins.types.json,
    "upstreamInfo": contents of meta.json,
}
```

The reason to return this all in a single response is so that clients can atomically get an upstreamInfo that matches data.

This can be used by tools that wish to work with the same data as Noogle programmatically, without needing to rerun the build process locally.