### PR TITLE
Properly support previews in GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: "build"
 on:
   push:
-  pull_request_target:
+  pull_request:
     branches: [ "main" ]
 env:
   cloudflare_project: noogle
@@ -31,31 +31,9 @@ jobs:
         projectName: ${{ env.cloudflare_project }}
         directory: ./result/lib/node_modules/noogle/out
         gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-    - name: Publish to Cloudflare Pages
-      id: publish
-      if: github.event_name == 'pull_request_target'
-      uses: cloudflare/pages-action@1
+    - name: Save output
+      if: github.event_name != 'push'
+      uses: actions/upload-artifact@v2
       with:
-        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }} 
-        projectName: noogle
-        directory: ./result/lib/node_modules/noogle/out
-        gitHubToken: ${{ secrets.GITHUB_TOKEN }}
-        branch: pr-${{ github.event.pull_request.number }}
-    - uses: peter-evans/create-or-update-comment@v3
-      if: github.event_name == 'pull_request_target'
-      with:
-        issue-number: ${{ github.event.pull_request.number }}
-        body: |
-          <!-- DEPLOYMENT_COMMENT -->
-          <table><tr><td><strong>Latest commit:</strong> </td><td>
-          <code>${{ github.event.pull_request.head.sha }}</code>
-          </td></tr>
-          <tr><td><strong>Preview URL:</strong></td><td>
-          <a href='${{ steps.publish.outputs.url }}'>${{ steps.publish.outputs.url }}</a>
-          </td></tr>
-          <tr><td><strong>Branch Preview URL:</strong></td><td>
-          <a href='https://pr-${{ github.event.pull_request.number }}.${{ env.cloudflare_project }}.pages.dev'>https://pr-${{ github.event.pull_request.number }}.${{ env.cloudflare_project }}.pages.dev</a>
-          </td></tr>
-          </table>
-        edit-mode: replace
+        name: out
+        path: ./result/lib/node_modules/noogle/out

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+name: preview
+on:
+  workflow_run:
+    workflows: ["build"]
+    types: ["completed"]
+env:
+  cloudflare_project: noogle
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+      pull-requests: write
+    steps:
+    - name: Fetch output
+      uses: actions/github-script@v3.1.0
+      with:
+        script: |
+         var artifacts = await github.actions.listWorkflowRunArtifacts({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            run_id: ${{github.event.workflow_run.id}},
+         });
+         var matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+           return artifact.name == "out"
+         })[0];
+         var download = await github.actions.downloadArtifact({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            artifact_id: matchArtifact.id,
+            archive_format: 'zip',
+         });
+         var fs = require('fs');
+         fs.writeFileSync('${{github.workspace}}/out.zip', Buffer.from(download.data));
+    - run: unzip out.zip
+    - name: Publish to Cloudflare Pages
+      id: publish
+      if: github.event_name == 'pull_request_target'
+      uses: cloudflare/pages-action@1
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        projectName: noogle
+        directory: ./out
+        branch: pr-${{ github.event.pull_request.number }}
+    - uses: peter-evans/create-or-update-comment@v3
+      if: github.event_name == 'pull_request_target'
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          <!-- DEPLOYMENT_COMMENT -->
+          <table><tr><td><strong>Latest commit:</strong> </td><td>
+          <code>${{ github.event.pull_request.head.sha }}</code>
+          </td></tr>
+          <tr><td><strong>Preview URL:</strong></td><td>
+          <a href='${{ steps.publish.outputs.url }}'>${{ steps.publish.outputs.url }}</a>
+          </td></tr>
+          <tr><td><strong>Branch Preview URL:</strong></td><td>
+          <a href='https://pr-${{ github.event.pull_request.number }}.${{ env.cloudflare_project }}.pages.dev'>https://pr-${{ github.event.pull_request.number }}.${{ env.cloudflare_project }}.pages.dev</a>
+          </td></tr>
+          </table>
+        edit-mode: replace


### PR DESCRIPTION
We need access to the Cloudflare token to write the preview page, but we don't want this token to be available to code controlled by the pull request. Before this change the action used `pull_request_target` to get has write permissions, but as a consequence, it ran on the target branch so that it didn't run untrusted code from the pull request, so it didn't preview the right thing.

Instead, follow the approach outlined in
https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/ by splitting the work into two workflows in the pull request case. The first runs the build without access to secrets and stores the build result as a GHA artifact, and the second fetches the artifact and publishes the preview without running untrusted code.

---

This is untested and will probably need some tweaking once it lands to see if it's working right.