### PR TITLE
builtins.getFlake: fix type signature

### DIFF
--- a/salt/src/builtins.types.json
+++ b/salt/src/builtins.types.json
@@ -48,7 +48,7 @@
   "genericClosure": { "fn_type": "genericClosure :: AttrSet -> [AttrSet]" },
   "getAttr": { "fn_type": "getAttr :: String -> AttrSet -> a" },
   "getEnv": { "fn_type": "getEnv :: String -> String" },
-  "getFlake": { "fn_type": "getFlake :: AttrSet -> AttrSet" },
+  "getFlake": { "fn_type": "getFlake :: String -> AttrSet" },
   "groupBy": { "fn_type": "groupBy :: (a -> b) -> [a] -> AttrSet" },
   "hasAttr": { "fn_type": "hasAttr :: String -> AttrSet -> Bool" },
   "hashFile": { "fn_type": "hashFile :: String -> Path -> String" },


### PR DESCRIPTION
The input is a string that contains either a flake URI or a path to a flake.

Eg:

    builtins.getFlake "github:NixOS/nixpkgs"