### PR TITLE
builtins.types: add type signature for addErrorContext

### DIFF
--- a/salt/src/builtins.types.json
+++ b/salt/src/builtins.types.json
@@ -1,6 +1,7 @@
 {
   "abort": { "fn_type": "abort :: String -> Never" },
   "add": { "fn_type": "add :: Number -> Number -> Number" },
+  "addErrorContext": { "fn_type": "addErrorContext :: String -> a -> a" },
   "all": { "fn_type": "all :: (a -> Bool) -> [a] -> Bool" },
   "any": { "fn_type": "any :: (a -> Bool) -> [a] -> Bool" },
   "attrNames": { "fn_type": "attrNames :: AttrSet -> [String]" },


### PR DESCRIPTION
might not be entirely accurate, but I found this function and really wanted to add documentation for it, because I think it's cool.

I would also be interested in writing more documentation for the builtins, adding examples and so on but I couldn't find anything more concrete on how noogle does this, so I would kindly ask for you to tell me :3 