### PR TITLE
gh.workflows: switch `update-nix{,pkgs}` names

### DIFF
--- a/.github/workflows/update-nix.yml
+++ b/.github/workflows/update-nix.yml
@@ -1,11 +1,16 @@
-name: update-nixpkgs-master-lock
+name: update-nix-master-lock
 on:
   workflow_dispatch: # allows manual triggering
   schedule:
-    - cron: "0 0 * * *" # runs daily at 00:00
+    - cron: "0 1 * * *" # runs daily at 01:00
 
 jobs:
   lockfile:
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -16,10 +21,11 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v25
+        uses: DeterminateSystems/update-flake-lock@v28
         with:
           token: ${{ secrets.GH_ACTIONS }}
-          pr-title: "Update: nixpkgs-master input"
+          pr-title: "Update: nix-master input"
           pr-labels: |
             auto-merge
-          inputs: nixpkgs-master
+          inputs: nix-master
+          branch: update_flake_lock_action_nix

--- a/.github/workflows/update-nixpkgs.yml
+++ b/.github/workflows/update-nixpkgs.yml
@@ -1,11 +1,16 @@
-name: update-nix-master-lock
+name: update-nixpkgs-master-lock
 on:
   workflow_dispatch: # allows manual triggering
   schedule:
-    - cron: "0 1 * * *" # runs daily at 00:00
+    - cron: "0 0 * * *" # runs daily at 00:00
 
 jobs:
   lockfile:
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -16,10 +21,11 @@ jobs:
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Update flake.lock
-        uses: DeterminateSystems/update-flake-lock@v25
+        uses: DeterminateSystems/update-flake-lock@v28
         with:
           token: ${{ secrets.GH_ACTIONS }}
-          pr-title: "Update: nix-master input"
+          pr-title: "Update: nixpkgs-master input"
           pr-labels: |
             auto-merge
-          inputs: nix-master
+          inputs: nixpkgs-master
+          branch: update_flake_lock_action_nixpkgs


### PR DESCRIPTION
Also restrict `GITHUB_TOKEN` permissions and use different branch names for PRs to avoid problems.

- the workflow names were mismatched:
  - `update-nix` was updating `nixpkgs-master`
  - `update-nixpkgs` was updating `nix-master`
- `branch` parameter for the action: https://github.com/DeterminateSystems/update-flake-lock/blob/main/action.yml#L19-L22
  When using the same branch name, the workflow generated updates might overwrite each other:
  <img width="2279" height="630" alt="image" src="https://github.com/user-attachments/assets/5c9bf448-89a6-48f8-8492-824cf6e0ef11" />
  https://github.com/nix-community/noogle/commit/2303d1abeb267cc1a4495ee1d60ded3c29d2d448
  https://github.com/nix-community/noogle/commit/07cbf03d7d6011f306f24bb8fbeffb2ff2208487

- The latest version of the actions suggests running with restricted permissions for `GITHUB_TOKEN`[^1]: https://github.com/DeterminateSystems/update-flake-lock/blob/v28/README.md?plain=1#L23-L27
  
  I couldn't find where it is documented that by default permissions are laxer, but this can be seen in the logs of one of the prior runs: https://github.com/nix-community/noogle/actions/runs/22607006984/job/65501204992#step:1:22
  
[^1]: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions