### PR TITLE
Update return type for fetchurl and fetchTarball

### DIFF
--- a/salt/src/builtins.types.json
+++ b/salt/src/builtins.types.json
@@ -33,8 +33,8 @@
   "elemAt": { "fn_type": "elemAt :: [a] -> Int -> a" },
   "fetchClosure": { "fn_type": "fetchClosure :: AttrSet -> AttrSet" },
   "fetchGit": { "fn_type": "fetchgit :: AttrSet -> AttrSet" },
-  "fetchTarball": { "fn_type": "fetchTarball :: AttrSet -> AttrSet" },
-  "fetchurl": { "fn_type": "fetchurl :: String -> AttrSet" },
+  "fetchTarball": { "fn_type": "fetchTarball :: AttrSet -> String" },
+  "fetchurl": { "fn_type": "fetchurl :: String -> String" },
   "filter": { "fn_type": "filter :: (a -> Bool) -> [a] -> [a]" },
   "filterSource": {
     "fn_type": "filterSource :: (Path -> String -> Bool) -> Path -> StorePath"


### PR DESCRIPTION
`fetchurl` and `fetchTarball` return a value of type string, not attrSet. The content of the string is a store path though.

Source: https://git.snix.dev/snix/snix/issues/202

Also, both fetchers can accept a string too, like

```nix
nix-repl> builtins.fetchurl "https://github.com/NixOS/nixpkgs/archive/91050ea1e57e50388fa87a3302ba12d188ef723a.tar.gz"
"/nix/store/2rfpqg0ghklb6i8xiy6z1fcd5b69kk2n-91050ea1e57e50388fa87a3302ba12d188ef723a.tar.gz"

nix-repl> builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/91050ea1e57e50388fa87a3302ba12d188ef723a.tar.gz"
"/nix/store/7adgvk5zdfq4pwrhsm3n9lzypb12gw0g-source"
```

But I didn't find another case where input is a `one of`. If it's okay, I could annotate it as 

```
"fetchurl": { "fn_type": "fetchurl :: (String | AttrSet) -> String" }
```