### PR TITLE
website: reset page on new search

### DIFF
--- a/website/src/components/layout/filterContext.tsx
+++ b/website/src/components/layout/filterContext.tsx
@@ -84,8 +84,12 @@ export const FilterProvider = ({
       page: +params.get("page")! || undefined,
       limit: +params.get("limit")! || undefined,
     });
-    if (page) query.set("page", page.toString());
-    if (limit) query.set("page", limit.toString());
+    if (page) {
+      query.set("page", page.toString());
+    } else {
+      query.delete("page");
+    }
+    if (limit) query.set("limit", limit.toString());
     router.push(`/${queryUrl}?${query.toString()}`);
   };
   return (


### PR DESCRIPTION
## What
A new search triggered via the search icon button now resets pagination to the first page. Searching via the URL (e.g. visiting [noogle.dev/q?term=map&page=2](https://noogle.dev/q/?term=map&page=2)), or with any other params, still applies the query filters to the search, with no change to that behavior.

## Why
`submit()` clones the current URL's `URLSearchParams`, which still carry the `page=N` from the previous result set. Since nothing cleared it on a fresh search, the new query opened on the old page. That produces the "No search results found" / "4 results" mismatch in #1649 when the new query returns fewer results than the previous one.

## How
When `submit()` is called without an explicit `page` (i.e. a new term/filter/clear; every caller except `BackButton`, which passes a saved page to restore, such as navigating to a previous URL from browser history), the stale `page` param is now deleted so results start from page 1. Also fixes an adjacent copy-paste bug where a passed `limit` was written into the `page` key instead of `limit`.

Fixes #1649
