### PR TITLE
flake: use triplet instead of default-linux

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -213,16 +213,16 @@
     },
     "systems": {
       "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "lastModified": 1776166891,
+        "narHash": "sha256-bI8yrEGjrohR5hkQox7UrxDH7XqrYMwI8SL/LrJ1+S8=",
         "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "repo": "triplet",
+        "rev": "6de7bc09397911ce03636afbcf6118745ab2cda0",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default-linux",
+        "repo": "triplet",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
     # --- Other flake inputs ---
     nixpkgs.url = "nixpkgs/nixos-unstable";
 
-    systems.url = "github:nix-systems/default-linux";
+    systems.url = "github:nix-systems/triplet";
     flake-parts.url = "github:hercules-ci/flake-parts";
     flake-parts.inputs.nixpkgs-lib.follows = "nixpkgs";
     treefmt-nix.url = "github:numtide/treefmt-nix";


### PR DESCRIPTION
This commit changes the systems input from default-linux to triplet, so that it additionally supports aarch64-darwin, which is the system I currently use.